### PR TITLE
XDiag, bufgix in Diag++ and a couple other minor doc/code updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.11.0 (2025-04-25)
+
+### Feat
+
+- noOp commit to force commitizen to do a minor bump
+
 ## 0.10.1 (2025-03-17)
 
 ### Fix

--- a/docs/materials/index.rst
+++ b/docs/materials/index.rst
@@ -47,13 +47,23 @@ It also implements:
     SIAM Review, 53 (2): 217-288.
 
   * `[TYUC2019] <https://arxiv.org/abs/1902.08651>`_: Joel A. Tropp, Alp
-    Yurtsever, Madeleine Udell, and Volkan Cevher. 2019. *“Streaming Low-rank
+    Yurtsever, Madeleine Udell, Volkan Cevher. 2019. *“Streaming Low-rank
     Matrix Approximation with an Application to Scientific Simulation”*. SIAM
     Journal on Scientific Computing 41 (4): A2430–63.
 
-  * `[BN2022] <https://arxiv.org/abs/2201.10684>`_: Robert A. Baston and Yuji
+  * `[BN2022] <https://arxiv.org/abs/2201.10684>`_: Robert A. Baston, Yuji
     Nakatsukasa. 2022. *“Stochastic diagonal estimation: probabilistic bounds and
     an improved algorithm”*.  CoRR abs/2201.10684.
+
+  * `[ETW2024] <https://arxiv.org/pdf/2301.07825>`_: Ethan N. Epperly,
+    Joel A. Tropp, Robert J. Webber. 2024. *“XTrace: Making the most of every
+    sample in stochastic trace estimation”*. SIAM Journal on Matrix Analysis
+    and Applications.
+
+  * `[FSMH2025] <https://openreview.net/forum?id=yGGoOVpBVP>`_ Andres Fernandez,
+    Frank Schneider, Maren Mahsereci, Philipp Hennig. 2025. *“Connecting Parameter
+    Magnitudes and Hessian Eigenspaces at Scale using Sketched Methods”*.
+    Transactions on Machine Learning Research.
 
 .. toctree::
    :maxdepth: 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,6 @@ match = '(?!example_).*\.py'
 name = "cz_conventional_commits"
 tag_format = "$version"
 version_scheme = "pep440"
-version = "0.10.1"
+version = "0.11.0"
 update_changelog_on_bump = true
 major_version_zero = true

--- a/skerch/distributed_decompositions.py
+++ b/skerch/distributed_decompositions.py
@@ -102,7 +102,7 @@ def orthogonalize(matrix, overwrite=False, return_R=False):
     if isinstance(matrix, torch.Tensor):
         Q, R = torch.linalg.qr(matrix, mode="reduced")
     else:
-        Q, R = scipy.linalg.qr(
+        Q, R, _ = scipy.linalg.qr(
             matrix,
             mode="economic",
             pivoting=True,

--- a/skerch/distributed_decompositions.py
+++ b/skerch/distributed_decompositions.py
@@ -85,9 +85,9 @@ def create_hdf5_layout(
 
 
 # ##############################################################################
-# # QR DECOMPOSITIONS
+# # MATRIX ROUTINE WRAPPERS
 # ##############################################################################
-def orthogonalize(matrix, overwrite=False):
+def orthogonalize(matrix, overwrite=False, return_R=False):
     """Orthogonalization of given matrix.
 
     :param matrix: matrix to orthogonalize, needs to be compatible with either
@@ -100,17 +100,34 @@ def orthogonalize(matrix, overwrite=False):
     assert h >= w, "Only non-fat matrices supported!"
     #
     if isinstance(matrix, torch.Tensor):
-        Q = torch.linalg.qr(matrix, mode="reduced")[0]
+        Q, R = torch.linalg.qr(matrix, mode="reduced")
     else:
-        Q = scipy.linalg.qr(
+        Q, R = scipy.linalg.qr(
             matrix,
             mode="economic",
             pivoting=True,
-        )[0]
+        )
     #
     if overwrite:
         matrix[:] = Q
-    return Q
+    if return_R:
+        return Q, R
+    else:
+        return Q
+
+
+def pinvert(matrix):
+    """Pseudo-inversion of a given matrix.
+
+    :param matrix: matrix to pseudo-invert, of shape ``(h, w)``. It needs to be
+      compatible with either ``scipy.linalg.pinv`` or ``torch.linalg.qr``.
+    :returns: Pseudoinverse of shape ``(w, h)``.
+    """
+    if isinstance(matrix, torch.Tensor):
+        result = torch.linalg.pinv(matrix)
+    else:
+        result = scipy.linalg.pinv(matrix)
+    return result
 
 
 # ##############################################################################

--- a/skerch/subdiagonals.py
+++ b/skerch/subdiagonals.py
@@ -88,7 +88,7 @@ def subdiag_hadamard_pattern(v, diag_idxs, use_fft=False):
 # ##############################################################################
 # # SKETCHED (SUB)-DIAGONAL ESTIMATORS
 # ##############################################################################
-def subdiagpp(
+def subdiagpp(  # noqa: C901
     lop,
     num_meas,
     lop_dtype,

--- a/skerch/subdiagonals.py
+++ b/skerch/subdiagonals.py
@@ -105,7 +105,7 @@ def subdiagpp(  # noqa: C901
 
       `[BN2022] <https://arxiv.org/abs/2201.10684>`_: Robert A. Baston and Yuji
       Nakatsukasa. 2022. *“Stochastic diagonal estimation: probabilistic bounds
-      and an improved algorithm”*.  CoRR abs/2201.10684.
+      and an improved algorithm”*. CoRR abs/2201.10684.
 
     Given a linear operator ``lop``, implements an unbiased diagonal estimator,
     composed of orthogonal deflation followed by Hutchinson estimation.

--- a/test/test_subdiagonals.py
+++ b/test/test_subdiagonals.py
@@ -403,6 +403,7 @@ def test_main_diags_xdiag(
                     # retrieve the true diag
                     diag = torch.diag(mat, diagonal=0)
                     # matrix-free estimation of the diag
+                    testt = mat.clone()
                     diag_est, _, _ = xdiag(
                         mat,
                         meas,  # rank of Q is actually half this
@@ -437,6 +438,8 @@ def test_main_diags_xdiag(
                         meas // 2,
                         0,
                     )[0]
-                    dist2 = torch.dist(diag2, diag_est)
+                    dist2 = torch.dist(diag, diag2)
                     rel_err2 = (dist2 / torch.norm(diag)).item()
-                    print(rel_err2)
+                    print(dist, dist2)
+
+                    # breakpoint()


### PR DESCRIPTION
# Description

* Implemented XDiag
* Bugfix in Diag++
* Diag++ top norm now is a float instead of a scalar tensor
* Updated docs, added XDiag to examples
* Added `pinvert` wrapper to decompositions. Also orthogonalize now optionally returns the R matrix


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Unit and integration tests passing
* Extended diag++ tests to xdiag
* added xdiag to integration

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

