### PR TITLE
Xdiagpp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.2.0 (2025-10-24)
+
+### Feat
+
+- Bugfix and restructure of diagonal estimators
+
 ## 1.1.0 (2025-10-16)
 
 ### Feat

--- a/docs/materials/for_developers.rst
+++ b/docs/materials/for_developers.rst
@@ -50,6 +50,14 @@ But they can take a substantial amount of time. A quicker (few minutes), yet sti
   make test-light
 
 
+A coverage report is produced at the end of the test. Detailed report with lines missing coverage can be also produced via:
+
+.. code:: bash
+
+  coverage report -m
+
+Make sure to check this report and ensure that tests have good coverage (CI pipeline will fail if coverage goes too low).
+
 
 Documentation and Integration Tests
 -----------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,6 @@ match = '(?!example_).*\.py'
 name = "cz_conventional_commits"
 tag_format = "$version"
 version_scheme = "pep440"
-version = "1.1.0"
+version = "1.2.0"
 update_changelog_on_bump = true
 major_version_zero = true

--- a/skerch/algorithms.py
+++ b/skerch/algorithms.py
@@ -146,9 +146,7 @@ class SketchedAlgorithmDispatcher:
                 conj=False,
             )
         else:
-            raise ValueError(
-                f"Unknown type! {mop_type} Supported: {supported}"
-            )
+            raise ValueError(f"Unknown type! {mop_type} Supported: {supported}")
         #
         return mop
 
@@ -613,7 +611,7 @@ def xhutchpp(  # noqa:C901
     r"""Diagonal and trace sketched approximation via Hutch/XDiag.
 
     In :func:`hutch` we see how to estimate the trace and diagonal via
-    Girard-Hutchinson and ``Hutch++``. This function extends this
+    Girard-Hutchinson/``Hutch++``. This function extends this
     functionality with ``XTrace/XDiag``
     `[ETW2024] <https://arxiv.org/pdf/2301.07825>`_, which allow
     us to perform ``x_dims`` dimensional deflation, and then recycle the
@@ -766,9 +764,7 @@ def xhutchpp(  # noqa:C901
         k, q = x_dims, gh_meas  # both nonzero
         result["tr"] = xtrace + (k * ytrace + q * defl["tr"]) / (k + q)
         if return_diag:
-            result["diag"][:] = xdiag + (k * ydiag + q * defl["diag"]) / (
-                k + q
-            )
+            result["diag"][:] = xdiag + (k * ydiag + q * defl["diag"]) / (k + q)
     #
     if x_dims >= 1:
         result["Q"] = Q

--- a/skerch/algorithms.py
+++ b/skerch/algorithms.py
@@ -597,7 +597,7 @@ def hutch(
     return result
 
 
-def xdiagpp(  # noqa:C901
+def xhutchpp(  # noqa:C901
     lop,
     lop_device,
     lop_dtype,
@@ -610,7 +610,7 @@ def xdiagpp(  # noqa:C901
     return_diag=True,
     cache_xmop=True,
 ):
-    r"""Diagonal and trace sketched approximation via Hutch++/XDiag.
+    r"""Diagonal and trace sketched approximation via Hutch/XDiag.
 
     In :func:`hutch` we see how to estimate the trace and diagonal via
     Girard-Hutchinson and ``Hutch++``. This function extends this
@@ -631,6 +631,13 @@ def xdiagpp(  # noqa:C901
       For the ``Hutch++`` estimator, run :func:`hutch` providing the
       desired ``Q_defl`` deflation matrix.
 
+    .. seealso::
+
+      `This blogpost <https://aferro.dynu.net/math/xdiagpp/>`_ provides
+      derivations and elaborates on the relationship between Hutch++
+      and XDiag, and how this can lead to a common implementation such as
+      this one.
+
     :param defl_dims: How many measurements will be used to obtain
       the :math:`Q` deflation matrix
     :param lop: The :math:`A` operator whose diagonal we wish to estimate.
@@ -649,11 +656,12 @@ def xdiagpp(  # noqa:C901
       used twice) is converted to an explicit matrix and kept around.
       This saves computation, since it does not need to be sampled twice,
       at the expense of the memory required to store its entries.
-    :returns: A tuple in the form ``d, (d_top, d_gh, Q, R)``, where
-      where ``(Q, R)`` is the QR decomposition of the sketch used to obtain
-      the deflation, ``d`` is the diagonal estimate, ``d_top``
-      is :math:`diag(Q \Psi Q^H A)` and ``t_gh`` is the G-H estimate of
-      :math:`tr((I -Q \Psi Q^H) A)`.
+    :returns: A dictionary in the form
+      ``{"tr": t, "diag": d, "Q": Q, "R": R, "Sh_k": S, "Psi": P}`` containing
+      trace and diagonal (if ``return_diag`` is true) estimations,
+      as well as the :math:`Q, R` matrices corresponding to the QR
+      decomposition of the deflation measurements, and the
+      :math:`S_k^H, \Psi` objects needed to compute the exchangeable estimator.
     """
     # housekeeping
     register = False  # set to True for seed debugging

--- a/skerch/algorithms.py
+++ b/skerch/algorithms.py
@@ -737,8 +737,8 @@ def xdiagpp(  # noqa:C901
         # Girard-Hutchinson on (optionally deflated) A
         defl = hutch(
             A_defl,
-            lop_dtype,
             lop_device,
+            lop_dtype,
             gh_meas,
             seed + x_dims,
             noise_type,

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -183,7 +183,7 @@ def eigh_test_helper(mat, idty, ews_rec, evs_rec, atol, by_mag=True):
 
 
 def diag_trace_test_helper(
-    diag, tr, idty, results, tr_tol, diag_tol, errcode=""
+    diag, tr, idty, results, tr_tol, diag_tol, q_tol, errcode=""
 ):
     """ """
     # tr
@@ -192,12 +192,11 @@ def diag_trace_test_helper(
     ), f"[{errcode}]: Bad trace?"
     # diag
     if "diag" in results:
-        assert (
-            relerr(diag, results["diag"]) < diag_tol
-        ), f"[{errcode}]: Bad diag?"
+        err = relerr(diag, results["diag"])
+        assert err < diag_tol, f"[{errcode}]: Bad diag?"
     # orth Q
     if "Q" in results:
-        Q = result["Q"]
+        Q = results["Q"]
         assert torch.allclose(
-            Q.H @ Q, idty, atol=tol
+            Q.H @ Q, idty, atol=q_tol
         ), f"[{errcode}]: Q not orthogonal?"

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -158,7 +158,9 @@ def eigh_test_helper(mat, idty, ews_rec, evs_rec, atol, by_mag=True):
     * The recovered eigvals are by descending magnitude/value
     * The devices and dtypes all match
     """
-    allclose = torch.allclose if isinstance(idty, torch.Tensor) else np.allclose
+    allclose = (
+        torch.allclose if isinstance(idty, torch.Tensor) else np.allclose
+    )
     diff = torch.diff if isinstance(idty, torch.Tensor) else np.diff
     V, Lbd, Vh = evs_rec, ews_rec, evs_rec.conj().T
     # correctness of result
@@ -178,3 +180,24 @@ def eigh_test_helper(mat, idty, ews_rec, evs_rec, atol, by_mag=True):
     if isinstance(mat, torch.Tensor):
         assert V.device == mat.device, "Incorrect eigvecs device!"
         assert Lbd.device == mat.device, "Incorrect eigvals device!"
+
+
+def diag_trace_test_helper(
+    diag, tr, idty, results, tr_tol, diag_tol, errcode=""
+):
+    """ """
+    # tr
+    assert (
+        relsumerr(tr, results["tr"], diag) < tr_tol
+    ), f"[{errcode}]: Bad trace?"
+    # diag
+    if "diag" in results:
+        assert (
+            relerr(diag, results["diag"]) < diag_tol
+        ), f"[{errcode}]: Bad diag?"
+    # orth Q
+    if "Q" in results:
+        Q = result["Q"]
+        assert torch.allclose(
+            Q.H @ Q, idty, atol=tol
+        ), f"[{errcode}]: Q not orthogonal?"

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -158,9 +158,7 @@ def eigh_test_helper(mat, idty, ews_rec, evs_rec, atol, by_mag=True):
     * The recovered eigvals are by descending magnitude/value
     * The devices and dtypes all match
     """
-    allclose = (
-        torch.allclose if isinstance(idty, torch.Tensor) else np.allclose
-    )
+    allclose = torch.allclose if isinstance(idty, torch.Tensor) else np.allclose
     diff = torch.diff if isinstance(idty, torch.Tensor) else np.diff
     V, Lbd, Vh = evs_rec, ews_rec, evs_rec.conj().T
     # correctness of result
@@ -185,7 +183,12 @@ def eigh_test_helper(mat, idty, ews_rec, evs_rec, atol, by_mag=True):
 def diag_trace_test_helper(
     diag, tr, idty, results, tr_tol, diag_tol, q_tol, errcode=""
 ):
-    """ """
+    """Helper to test correctness of diag/trace estimators.
+
+    * ``results["tr"]`` via relsumerr
+    * If present, ``results["diag"]`` via relerr
+    * If present, orthogonality of ``results["Q"]``
+    """
     # tr
     assert (
         relsumerr(tr, results["tr"], diag) < tr_tol
@@ -193,7 +196,7 @@ def diag_trace_test_helper(
     # diag
     if "diag" in results:
         err = relerr(diag, results["diag"])
-        assert err < diag_tol, f"[{errcode}]: Bad diag?"
+        assert err < diag_tol, f"[{errcode}]: Bad diag? {err}"
     # orth Q
     if "Q" in results:
         Q = results["Q"]

--- a/test/test_algorithms.py
+++ b/test/test_algorithms.py
@@ -720,22 +720,68 @@ def test_diag_trace_correctness(  # noqa:C901
                                     tol,
                                     errcode=f"XDiag (cache={cache_xmop})",
                                 )
+                                Q = result["Q"]
+                            # XDiag++:
+                            for cache_xmop in (True, False):
+                                result = xdiagpp(
+                                    lop,
+                                    device,
+                                    dtype,
+                                    xdims,
+                                    gh_meas,
+                                    seed,
+                                    noise_type,
+                                    meas_blocksize=None,
+                                    dispatcher=MyDispatcher,
+                                    return_diag=return_diag,
+                                    cache_xmop=cache_xmop,
+                                )
+                                diag_trace_test_helper(
+                                    D,
+                                    tr,
+                                    idty,
+                                    result,
+                                    trace_tol,
+                                    diag_tol,
+                                    tol,
+                                    errcode=f"XDiag++ (cache={cache_xmop})",
+                                )
+                            # Just deflation
+                            assert (
+                                relerr(D, (Q.T * (Q.H @ mat)).sum(0)) < 0.5
+                            ), "Bad diag deflation?"
+                            # # Hutch++
+                            # result = hutch(
+                            #     lop,
+                            #     device,
+                            #     dtype,
+                            #     gh_meas,
+                            #     seed,
+                            #     noise_type,
+                            #     meas_blocksize=None,
+                            #     return_diag=return_diag,
+                            #     dispatcher=MyDispatcher,
+                            #     defl_Q=Q,
+                            # )
+                            # diag_trace_test_helper(
+                            #     D,
+                            #     tr,
+                            #     idty,
+                            #     result,
+                            #     trace_tol,
+                            #     diag_tol,
+                            #     tol,
+                            #     errcode="Hutch++",
+                            # )
+                            # XDiag++
+
+                            # breakpoint()
                             """
                             TODO:
-
-                            * xdiag is erroring for diag. Why?
-                              - error is in XDIAG complex bloated
-                              - float bloated is OK
-                            * finish formal tests
 
                             * get rid of gh meas for triang
                             * lint etc release
                             """
-                            # Just deflation
-                            # Hutch++
-                            # XDiag++
-
-                            # breakpoint()
 
 
 # ##############################################################################


### PR DESCRIPTION
# Description

* XDiag was not correctly implemented
* There is a direct relationship between XDiag and Hutch++ that allows to share most of the code

As a consequence, this PR implements the following changes:
* Refactored diagonal estimators into plain Girard-Hutchinson and XHutch++, which combines Hutch++ and XDiag/Xtrace
* Both estimators now provide diagonal and trace, tested for correctness
* Updated subsequent docs and tests

It breaks interface of previous diag estimators, but this doesn't warrant a major version since we are at early adoption.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Extensive unit and integration tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

